### PR TITLE
Fix Issue #134

### DIFF
--- a/src/Nito.AsyncEx.Coordination/AsyncReaderWriterLock.cs
+++ b/src/Nito.AsyncEx.Coordination/AsyncReaderWriterLock.cs
@@ -234,11 +234,8 @@ namespace Nito.AsyncEx
         /// </summary>
         private void ReleaseWaiters()
         {
-            if (_locksHeld != 0)
-                return;
-
             // Give priority to writers.
-            if (!_writerQueue.IsEmpty)
+            if (_locksHeld == 0 && !_writerQueue.IsEmpty)
             {
                 _locksHeld = -1;
                 _writerQueue.Dequeue(new WriterKey(this));
@@ -246,7 +243,7 @@ namespace Nito.AsyncEx
             }
 
             // Then to readers.
-            while (!_readerQueue.IsEmpty)
+            while (_locksHeld >= 0 && _writerQueue.IsEmpty && !_readerQueue.IsEmpty)
             {
                 _readerQueue.Dequeue(new ReaderKey(this));
                 ++_locksHeld;


### PR DESCRIPTION
AsyncReaderWriterLock does release next waiter for write lock if any, or else does release waiters for a read lock when an attempt to enter the write lock is canceled.

Resolve issue StephenCleary/AsyncEx/issues/134