### PR TITLE
Taken event that fires when AsyncLock is taken or released.

### DIFF
--- a/src/Nito.AsyncEx.Coordination/AsyncLock.cs
+++ b/src/Nito.AsyncEx.Coordination/AsyncLock.cs
@@ -52,6 +52,11 @@ namespace Nito.AsyncEx
         private bool _taken;
 
         /// <summary>
+        /// Fires when lock is taken or released.
+        /// </summary>
+        public event Action<bool> Taken;
+
+        /// <summary>
         /// The queue of TCSs that other tasks are awaiting to acquire the lock.
         /// </summary>
         private readonly IAsyncWaitQueue<IDisposable> _queue;
@@ -105,6 +110,7 @@ namespace Nito.AsyncEx
                 {
                     // If the lock is available, take it immediately.
                     _taken = true;
+                    Taken?.Invoke(_taken);
                     return Task.FromResult<IDisposable>(new Key(this));
                 }
                 else
@@ -159,7 +165,10 @@ namespace Nito.AsyncEx
             lock (_mutex)
             {
                 if (_queue.IsEmpty)
+                {
                     _taken = false;
+                    Taken?.Invoke(_taken);
+                }
                 else
                     _queue.Dequeue(new Key(this));
             }

--- a/test/AsyncEx.Coordination.UnitTests/AsyncLockUnitTests.cs
+++ b/test/AsyncEx.Coordination.UnitTests/AsyncLockUnitTests.cs
@@ -257,5 +257,42 @@ namespace UnitTests
                 task1.Wait();
             });
         }
+
+        [Fact]
+        public async Task AsyncLock_TakenFires()
+        {
+            int takenCount = 0;
+            int releasedCount = 0;
+            var mutex = new AsyncLock();
+
+            void OnTaken(bool taken)
+            {
+                if (taken)
+                {
+                    takenCount++;
+                }
+                else
+                {
+                    releasedCount++;
+                }
+            }
+            mutex.Taken += OnTaken;
+
+            using (mutex.Lock())
+            {
+                Assert.Equal(1, takenCount);
+                Assert.Equal(0, releasedCount);
+            }
+            Assert.Equal(1, takenCount);
+            Assert.Equal(1, releasedCount);
+
+            using (await mutex.LockAsync())
+            {
+                Assert.Equal(2, takenCount);
+                Assert.Equal(1, releasedCount);
+            }
+            Assert.Equal(2, takenCount);
+            Assert.Equal(2, releasedCount);
+        }
     }
 }


### PR DESCRIPTION
It would be useful to have an event that fires when AsyncLock is taken or released. I would use this to update GUI elements without having to add additional logic every time the lock is used.