### PR TITLE
Change Asynchronously to Synchronously in WriterLock() documentation

### DIFF
--- a/src/Nito.AsyncEx.Coordination/AsyncReaderWriterLock.cs
+++ b/src/Nito.AsyncEx.Coordination/AsyncReaderWriterLock.cs
@@ -221,7 +221,7 @@ namespace Nito.AsyncEx
         }
 
         /// <summary>
-        /// Asynchronously acquires the lock as a writer. Returns a disposable that releases the lock when disposed. This method may block the calling thread.
+        /// Synchronously acquires the lock as a writer. Returns a disposable that releases the lock when disposed. This method may block the calling thread.
         /// </summary>
         /// <returns>A disposable that releases the lock when disposed.</returns>
         public IDisposable WriterLock()


### PR DESCRIPTION
Something small I noticed while using this (wonderful) library. 