### PR TITLE
Target net461

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,4 @@
-# build.yml v1.5
-# 1.5 - Run under Windows to cover the net461 target.
+# build.yml v1.4
 # 1.4 - Avoid set-env.
 # 1.3 - Include tag workflow in this file.
 # 1.2 - Define DOTNET_SKIP_FIRST_TIME_EXPERIENCE/NUGET_XMLDOC_MODE.
@@ -19,7 +18,7 @@ env:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
 
     - name: Dump context

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,5 @@
-# build.yml v1.4
+# build.yml v1.5
+# 1.5 - Run under Windows to cover the net461 target.
 # 1.4 - Avoid set-env.
 # 1.3 - Include tag workflow in this file.
 # 1.2 - Define DOTNET_SKIP_FIRST_TIME_EXPERIENCE/NUGET_XMLDOC_MODE.
@@ -18,7 +19,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     steps:
 
     - name: Dump context

--- a/src/Nito.AsyncEx.Context/Nito.AsyncEx.Context.csproj
+++ b/src/Nito.AsyncEx.Context/Nito.AsyncEx.Context.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>A single-threaded async-compatible context.</Description>
-    <TargetFrameworks>netstandard1.3;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard2.0;net461</TargetFrameworks>
     <PackageTags>$(PackageTags);synchronizationcontext</PackageTags>
   </PropertyGroup>
 

--- a/src/Nito.AsyncEx.Coordination/AsyncWaitQueue.cs
+++ b/src/Nito.AsyncEx.Coordination/AsyncWaitQueue.cs
@@ -31,13 +31,13 @@ namespace Nito.AsyncEx
         /// Removes a single entry in the wait queue and completes it. This method may only be called if <see cref="IsEmpty"/> is <c>false</c>. The task continuations for the completed task must be executed asynchronously.
         /// </summary>
         /// <param name="result">The result used to complete the wait queue entry. If this isn't needed, use <c>default(T)</c>.</param>
-        void Dequeue(T result = default(T));
+        void Dequeue(T? result = default);
 
         /// <summary>
         /// Removes all entries in the wait queue and completes them. The task continuations for the completed tasks must be executed asynchronously.
         /// </summary>
         /// <param name="result">The result used to complete the wait queue entries. If this isn't needed, use <c>default(T)</c>.</param>
-        void DequeueAll(T result = default(T));
+        void DequeueAll(T? result = default);
 
         /// <summary>
         /// Attempts to remove an entry from the wait queue and cancels it. The task continuations for the completed task must be executed asynchronously.
@@ -111,15 +111,15 @@ namespace Nito.AsyncEx
             return tcs.Task;
         }
 
-        void IAsyncWaitQueue<T>.Dequeue(T result)
+        void IAsyncWaitQueue<T>.Dequeue(T? result)
         {
-            _queue.RemoveFromFront().TrySetResult(result);
+            _queue.RemoveFromFront().TrySetResult(result!);
         }
 
-        void IAsyncWaitQueue<T>.DequeueAll(T result)
+        void IAsyncWaitQueue<T>.DequeueAll(T? result)
         {
             foreach (var source in _queue)
-                source.TrySetResult(result);
+                source.TrySetResult(result!);
             _queue.Clear();
         }
 

--- a/src/Nito.AsyncEx.Coordination/Nito.AsyncEx.Coordination.csproj
+++ b/src/Nito.AsyncEx.Coordination/Nito.AsyncEx.Coordination.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nito.Collections.Deque" Version="1.1.0" />
+    <PackageReference Include="Nito.Collections.Deque" Version="1.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Nito.AsyncEx.Coordination/Nito.AsyncEx.Coordination.csproj
+++ b/src/Nito.AsyncEx.Coordination/Nito.AsyncEx.Coordination.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Asynchronous coordination primitives.</Description>
-    <TargetFrameworks>netstandard1.3;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard2.0;net461</TargetFrameworks>
     <PackageTags>$(PackageTags);asynclock;asynclazy</PackageTags>
   </PropertyGroup>
 

--- a/src/Nito.AsyncEx.Interop.WaitHandles/Nito.AsyncEx.Interop.WaitHandles.csproj
+++ b/src/Nito.AsyncEx.Interop.WaitHandles/Nito.AsyncEx.Interop.WaitHandles.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Task wrappers for WaitHandles.</Description>
-    <TargetFrameworks>netstandard1.3;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard2.0;net461</TargetFrameworks>
     <PackageTags>$(PackageTags);waithandle</PackageTags>
   </PropertyGroup>
 

--- a/src/Nito.AsyncEx.Oop/Nito.AsyncEx.Oop.csproj
+++ b/src/Nito.AsyncEx.Oop/Nito.AsyncEx.Oop.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Interfaces and utility methods for combining async with OOP.</Description>
-    <TargetFrameworks>netstandard1.3;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard2.0;net461</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Nito.AsyncEx.Tasks/Nito.AsyncEx.Tasks.csproj
+++ b/src/Nito.AsyncEx.Tasks/Nito.AsyncEx.Tasks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Common helper methods for tasks as used in asynchronous programming.</Description>
-    <TargetFrameworks>netstandard1.3;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard2.0;net461</TargetFrameworks>
     <PackageTags>$(PackageTags);taskfactory;cancellationtoken;taskcompletionsource</PackageTags>
   </PropertyGroup>
 

--- a/src/Nito.AsyncEx/Nito.AsyncEx.csproj
+++ b/src/Nito.AsyncEx/Nito.AsyncEx.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Title>Async and Task Helpers</Title>
     <Description>A helper library for the Task-Based Asynchronous Pattern (TAP).</Description>
-    <TargetFrameworks>netstandard1.3;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard2.0;net461</TargetFrameworks>
     <PackageTags>async;await;async-await;task;asynchronous;nito;nitro</PackageTags>
     <IsMetapackage>true</IsMetapackage>
   </PropertyGroup>

--- a/src/Nito.AsyncEx/Nito.AsyncEx.csproj
+++ b/src/Nito.AsyncEx/Nito.AsyncEx.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nito.Cancellation" Version="1.1.0" />
+    <PackageReference Include="Nito.Cancellation" Version="1.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/project.props
+++ b/src/project.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>5.1.0</VersionPrefix>
+    <VersionPrefix>5.1.1</VersionPrefix>
     <Authors>Stephen Cleary</Authors>
     <PackageTags>task;async</PackageTags>
     <RootNamespace>Nito.AsyncEx</RootNamespace>

--- a/test/AsyncEx.Context.UnitTests/AsyncEx.Context.UnitTests.csproj
+++ b/test/AsyncEx.Context.UnitTests/AsyncEx.Context.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/AsyncEx.Coordination.UnitTests/AsyncEx.Coordination.UnitTests.csproj
+++ b/test/AsyncEx.Coordination.UnitTests/AsyncEx.Coordination.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/AsyncEx.Interop.WaitHandles.UnitTests/AsyncEx.Interop.WaitHandles.UnitTests.csproj
+++ b/test/AsyncEx.Interop.WaitHandles.UnitTests/AsyncEx.Interop.WaitHandles.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/AsyncEx.Oop.UnitTests/AsyncEx.Oop.UnitTests.csproj
+++ b/test/AsyncEx.Oop.UnitTests/AsyncEx.Oop.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/AsyncEx.Tasks.UnitTests/AsyncEx.Tasks.UnitTests.csproj
+++ b/test/AsyncEx.Tasks.UnitTests/AsyncEx.Tasks.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This pr adds the additional target `net461`, and updates respective tests.

This partly resolves #173 - pending adding `net461` to supporting dependencies, namely `Nito.Cancellation` and `Nito.Collections.Deque`.

Related:
- [x] https://github.com/StephenCleary/Deque/pull/5
- [x] https://github.com/StephenCleary/Cancellation/pull/3